### PR TITLE
Set up a Gatsby-based site

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,8 @@
+node_modules/
+
+logs
+*.log
+
+pids
+*.pid
+*.seed

--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,50 @@
+# Contributor Code of Conduct
+
+As contributors and maintainers of this project, and in the interest of
+fostering an open and welcoming community, we pledge to respect all people who
+contribute through reporting issues, posting feature requests, updating
+documentation, submitting pull requests or patches, and other activities.
+
+We are committed to making participation in this project a harassment-free
+experience for everyone, regardless of level of experience, gender, gender
+identity and expression, sexual orientation, disability, personal appearance,
+body size, race, ethnicity, age, religion, or nationality.
+
+Examples of unacceptable behavior by participants include:
+
+* The use of sexualized language or imagery  
+* Personal attacks  
+* Trolling or insulting/derogatory comments  
+* Public or private harassment  
+* Publishing other's private information, such as physical or electronic  
+  addresses, without explicit permission  
+* Other unethical or unprofessional conduct
+
+Project maintainers have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other contributions
+that are not aligned to this Code of Conduct, or to ban temporarily or
+permanently any contributor for other behaviors that they deem inappropriate,
+threatening, offensive, or harmful.
+
+By adopting this Code of Conduct, project maintainers commit themselves to
+fairly and consistently applying these principles to every aspect of managing
+this project. Project maintainers who do not follow or enforce the Code of
+Conduct may be permanently removed from the project team.
+
+This code of conduct applies both within project spaces and in public spaces
+when an individual is representing the project or its community.
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be
+reported by contacting a project maintainer via [our issue tracker](https://github.com/rackt/rackt.github.io/issues). All 
+complaints will be reviewed and investigated and will result in a response that
+is deemed necessary and appropriate to the circumstances. Maintainers are
+obligated to maintain confidentiality with regard to the reporter of an
+incident.  
+
+
+This Code of Conduct is adapted from the [Contributor Covenant][homepage],
+version 1.3.0, available at
+[http://contributor-covenant.org/version/1/3/0/][version]
+
+[homepage]: http://contributor-covenant.org
+[version]: http://contributor-covenant.org/version/1/3/0/

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,43 @@
+# Contributing to Rackt
+
+Rackt is an organization focused on creating high quality libraries and components for the React ecosystem. We want your help with making these projects the best they can be. Use this document as a guide for how you can contribute to this Rackt project.
+
+## [Code of Conduct](CODE_OF_CONDUCT.md)
+This project has adopted a Code of Conduct that we expect project participants to adhere to. Please read [the full text](CODE_OF_CONDUCT.md) so that you can understand what actions will and will not be tolerated.
+
+## Pull Requests
+
+Good pull requests—patches, improvements, new features—are a fantastic help. They should remain focused in scope and avoid containing unrelated commits.
+
+**Please ask first** before embarking on any significant pull request (e.g. implementing features, refactoring code, porting to a different language), otherwise you risk spending a lot of time working on something that the project's developers might not want to merge into the project.
+
+Adhering to the following process is the best way to get your work included in the project:
+
+1. [Fork the project](https://help.github.com/articles/fork-a-repo/)
+
+2. Create a new topic branch (off the main project development branch) to contain your feature, change, or fix:
+
+   ```bash
+   git checkout -b <topic-branch-name>
+   ```
+
+3. Commit your changes in logical chunks. Please adhere to these [git commit message guidelines](http://tbaggery.com/2008/04/19/a-note-about-git-commit-messages.html) or your code is unlikely be merged into the main project. Use git's [interactive rebase](https://help.github.com/articles/interactive-rebase) feature to tidy up your commits before making them public.
+
+4. Locally merge (or rebase) the upstream development branch into your topic branch:
+
+   ```bash
+   git pull [--rebase] upstream master
+   ```
+
+5. Push your topic branch up to your fork:
+
+   ```bash
+   git push origin <topic-branch-name>
+   ```
+
+6. [Open a Pull Request](https://help.github.com/articles/using-pull-requests/)
+    with a clear title and description against the `master` branch.
+
+## Licensing
+
+By contributing your code, you agree to license your contribution under the [MIT License](LICENSE).

--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,21 @@
+The MIT License (MIT)
+
+Copyright (c) 2015
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/README.md
+++ b/README.md
@@ -1,3 +1,22 @@
 # rackt.org
 
 It's Racktastic!
+
+This repo houses the main rackt.org site along with the documentation for any
+Rackt projects. Those projects should keep their documentation in a top-level
+`docs` path within their respective repos. Any documentation should be in
+Markdown format and have a table of contents in their `docs/README.md` file.
+
+## Development
+
+We build the site using [Gatsby](https://github.com/gatsbyjs/gatsby), which
+provides a [webpack](https://webpack.github.io/) server with hot reloading of
+content. To develop locally with the docs, clone this repo and run these
+commands:
+
+```sh
+npm install
+npm start
+```
+Then open up [localhost:8000](http://localhost:8000/) in your browser and start
+working. Any changes you make should be reflected in your browser immediately.

--- a/README.md
+++ b/README.md
@@ -1,0 +1,3 @@
+# rackt.org
+
+It's Racktastic!

--- a/app.js
+++ b/app.js
@@ -1,0 +1,11 @@
+exports.loadContext = function(callback) {
+  var context;
+  context = require.context('./pages', true);
+  if (module.hot) {
+    module.hot.accept(context.id, function() {
+      context = require.context('./pages', true);
+      return callback(context);
+    });
+  }
+  return callback(context);
+};

--- a/config.toml
+++ b/config.toml
@@ -1,0 +1,1 @@
+siteTitle="Gatsby Starter Site"

--- a/html.jsx
+++ b/html.jsx
@@ -1,0 +1,38 @@
+import React from 'react';
+import Typography from 'typography';
+import DocumentTitle from 'react-document-title';
+
+var TypographyStyle = new Typography().TypographyStyle;
+
+module.exports = React.createClass({
+  getDefaultProps: function() {
+    return {
+      body: ""
+    };
+  },
+
+  render: function() {
+    var title;
+    title = DocumentTitle.rewind();
+    if (this.props.title) {
+      title = this.props.title;
+    }
+
+    return (
+      <html lang="en">
+        <head>
+          <meta charSet="utf-8"/>
+          <meta httpEquiv="X-UA-Compatible" content="IE=edge"/>
+          <meta name='viewport' content='width=device-width, initial-scale=1.0 maximum-scale=1.0'/>
+          <title>{title}</title>
+          <link rel="shortcut icon" href={this.props.favicon}/>
+          <TypographyStyle/>
+        </head>
+        <body>
+          <div id="react-mount" dangerouslySetInnerHTML={{__html: this.props.body}} />
+          <script src="/bundle.js"/>
+        </body>
+      </html>
+    );
+  }
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,35 @@
+{
+  "name": "rackt.github.io",
+  "version": "1.0.0",
+  "description": "The Rackt.org website",
+  "author": "Tim Dorr <timdorr@timdorr.com>",
+  "license": "MIT",
+  "homepage": "https://rackt.org",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/rackt/rackt.github.io.git"
+  },
+  "bugs": {
+    "url": "https://github.com/rackt/rackt.github.io/issues"
+  },
+  "keywords": [
+    "rackt",
+    "react",
+    "gatsby",
+    "documentation"
+  ],
+  "main": "app.js",
+  "scripts": {
+    "start": "gatsby serve"
+  },
+  "dependencies": {
+    "react": "^0.13.3",
+    "react-document-title": "^1.0.2",
+    "react-responsive-grid": "^0.2.0",
+    "react-router": "^0.13.3",
+    "typography": "^0.3.6"
+  },
+  "devDependencies": {
+    "gatsby": "^0.6.2"
+  }
+}

--- a/pages/_template.jsx
+++ b/pages/_template.jsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import { RouteHandler, Link, State } from 'react-router';
+import { Container, Grid, Breakpoint, Span } from 'react-responsive-grid';
+import Typography from 'typography';
+
+var typography = new Typography();
+var rhythm = typography.rhythm, fontSizeToMS = typography.fontSizeToMS;
+
+module.exports = React.createClass({
+  mixins: [State],
+
+  render: function() {
+    return (
+      <div>
+        <Container
+          style={{
+            maxWidth: 960,
+            padding: `${rhythm(1)} ${rhythm(1/2)}`,
+            paddingTop: 0
+          }}
+        >
+          <RouteHandler typography={typography} {...this.props}/>
+        </Container>
+      </div>
+    );
+  }
+});

--- a/pages/index.md
+++ b/pages/index.md
@@ -1,0 +1,2 @@
+# Hi people
+Welcome to your new Gatsby site.


### PR DESCRIPTION
Closes #1 (obviously!)

This is just the basic gatsby starter kit for now. Looks like we have some work to do with updating the versions of `react` and `react-router`, but nothing too crazy. 

If we have any upstream PRs with @gatsbyjs, mention this PR (`rackt/rackt.github.io#1`) so we can track those changes landing in their master or NPM.